### PR TITLE
feat(agent): add grilling skill entry

### DIFF
--- a/agent/skills/grilling/SKILL.md
+++ b/agent/skills/grilling/SKILL.md
@@ -10,3 +10,5 @@ Ask the questions one at a time, waiting for feedback on each question before co
 If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
 
 Do not act on it until I confirm we have reached a shared understanding.
+
+Ask through whichever picker tool the toolset offers — `AskUserQuestion` in Claude Code, `request_user_input` in Codex, Plan mode only — so answering costs me a keystroke. Without one, ask in prose rather than hand-rolling a menu.


### PR DESCRIPTION
## 背景と目的

Grilling では質問を一つずつ出す規範があるが、利用可能な選択 UI を優先する指示がなかった。
回答の入力負荷を下げつつ、選択肢を使えない環境でも同じ対話を継続できるようにする。

## 概要

利用可能な picker を優先し、存在しない環境では文章で質問するフォールバックを追加した。

## 影響範囲

Grilling スキルを使う対話で、選択肢を提示できる環境では picker を使う。
既存の質問順序、設定、外部 API、利用者向けの契約、デプロイ手順は変更しない。

## 検証したこと

`git diff --cached --check` が成功したことを確認した。
`ruby -e 'require "yaml"; YAML.load_file("agent/skills/grilling/agents/openai.yaml")'` で既存の UI 定義 YAML を読み込めることを確認した。

## レビューしてほしい観点

picker が利用できない環境への文章質問フォールバックと、既存の一問ずつ確認する制約の両立が適切か確認してほしい。

## 非目標

質問内容や Grilling の意思決定手順は変更しない。
本 PR は回答方法の選択だけを扱うため。