### PR TITLE
fix(git-hooks): don't skip local hook after protected-branch confirm

### DIFF
--- a/home/linux/git-hooks/pre-commit
+++ b/home/linux/git-hooks/pre-commit
@@ -14,7 +14,6 @@ case "$branch" in
             "Y" | "y" | "yes" | "Yes" | "YES" ) echo "OK. commit start.";;
             * ) echo "commit failed.";exit 1;;
         esac
-        exit 0
 		;;
 esac
 

--- a/home/linux/git-hooks/pre-push
+++ b/home/linux/git-hooks/pre-push
@@ -17,7 +17,6 @@ do
                 "Y" | "y" | "yes" | "Yes" | "YES" ) echo "OK. commit start.";;
                 * ) echo "commit failed.";exit 1;;
             esac
-            exit 0
             ;;
 	esac
 done


### PR DESCRIPTION
## 背景

`git-hooks/pre-commit` と `pre-push` は、`main`/`master`/`develop` への commit/push 時に確認プロンプトを出し、承認後は `_local-hook-exec` を source してリポジトリ固有の `.git/hooks/<hook>` があれば実行する設計になっている。
しかし承認処理の直後に置かれた `exit 0` が case 分岐の外側で無条件に実行されるため、`y`/`n` どちらの回答でも到達し、承認 (`y`) した場合でも `_local-hook-exec` へ到達せずスクリプトが終了していた。
結果として保護ブランチへの commit/push を承認したときだけ、リポジトリ固有フックが無言でスキップされていた。この bug はリポジトリのレビュー中に発見した。

## 概要

`pre-commit` と `pre-push` の確認 case ブロック末尾にあった不要な `exit 0` を削除し、承認後に `_local-hook-exec` へ fall through するようにした。

## 変更内容

両ファイルとも保護ブランチの確認ロジックは同一構造で、同じ箇所に同じ `exit 0` があった。
`* ) echo "commit failed."; exit 1 ;;` は拒否時の即時中断としてそのまま残し、承認時 (`Y`/`y`/`yes`/`Yes`/`YES`) だけ case を抜けたあと `exit 0` を通らずに末尾の `. $(dirname $0)/_local-hook-exec` へ到達するようにした。

## 影響範囲

- `pre-commit` / `pre-push` フックを利用している開発者に影響する。今後は保護ブランチへの commit/push で承認したあと、リポジトリ固有の `.git/hooks/pre-commit` `.git/hooks/pre-push` が存在すれば実行されるようになる(従来は実行されていなかった)。
- 該当フックを持たないリポジトリでは `_local-hook-exec` が何もせず正常終了するため、挙動は変わらない。
- 拒否時 (`N`/無回答など) の挙動は変更していない。

## 検証

- [x] `bash -n home/linux/git-hooks/pre-commit && bash -n home/linux/git-hooks/pre-push`：構文エラーなし
- [ ] 未検証：実際の commit/push 操作での対話的な動作確認(保護ブランチ上でリポジトリ固有フックがある状態から承認後に実行されること)は未実施

## レビュー観点

- `exit 0` 削除後も拒否時 (`* ) ... exit 1 ;;`) の挙動が変わっていないか
- 承認後に `_local-hook-exec` まで正しく fall through するか(`pre-commit`/`pre-push` 両方)
