### PR TITLE
feat(tmux): enable clipboard integration via set-clipboard

### DIFF
--- a/home/linux/.tmux.conf
+++ b/home/linux/.tmux.conf
@@ -1,1 +1,2 @@
 set -g mouse on
+set -s set-clipboard on


### PR DESCRIPTION
## 背景

`home/linux/.tmux.conf` はマウス操作の有効化のみで、クリップボード連携は未設定だった。
tmux の copy-mode で選択した内容がそのままでは OS のクリップボードへ届かず、外部ツールや手動操作が必要だった。

## 概要

`set -s set-clipboard on` を追加し、tmux がターミナル側のクリップボードエスケープシーケンス(xterm(1) の `Ms` エスケープシーケンス)を送受信できるようにした。

## 変更内容

`set-clipboard` を `on` にすると、tmux は自身のバッファへエスケープシーケンス経由で書き込むことを許可しつつ、ターミナル側のクリップボードへも反映を試みる(`external` はターミナル側のみでアプリケーションからの tmux バッファ書き込みは無視、`off` は両方無効)。今回は tmux 内外どちらの操作でもクリップボードに反映させたいため `on` を選んだ。
この機能を使うには接続先ターミナル側で該当エスケープシーケンスが許可されている必要がある場合がある(例: xterm は `disallowedWindowOps` の設定変更が必要)。

## 影響範囲

- `home/linux/.tmux.conf` を使う環境にのみ影響する。既存の設定を変更するものではなく追加のみで、対応していないターミナルでは無視される。
- ターミナル側がこのエスケープシーケンスを許可していない場合、設定自体は反映されるが実際にクリップボードへは反映されない。

## 検証

- [x] `tmux -f home/linux/.tmux.conf new-session -d` の後 `tmux show-options -s set-clipboard` で `set-clipboard on` を確認
- [ ] 未検証：実際のターミナル(iTerm2 / WezTerm 等)経由での copy-mode 選択がクリップボードへ反映されることの手動確認は未実施

## レビュー観点

- `set-clipboard on` の選択(`external` ではなく)が、tmux 内外双方向の連携という意図に合っているか
