### PR TITLE
grillingスキルのピッカー文を短く整理

### DIFF
--- a/agent/skills/grilling/SKILL.md
+++ b/agent/skills/grilling/SKILL.md
@@ -11,4 +11,4 @@ If a *fact* can be found by exploring the environment (filesystem, tools, etc.),
 
 Do not act on it until I confirm we have reached a shared understanding.
 
-Ask through whichever picker tool the toolset offers — `AskUserQuestion` in Claude Code, `request_user_input` in Codex, Plan mode only — so answering costs me a keystroke. Without one, ask in prose rather than hand-rolling a menu.
+When the answer narrows to four or fewer distinct options, use the toolset's picker (`AskUserQuestion` in Claude Code, `request_user_input` in Codex) so answering costs a keystroke. Otherwise ask in prose — never pad, merge, or drop candidates to force a menu, and don't hand-roll one when no picker is available.

--- a/agent/skills/grilling/SKILL.md
+++ b/agent/skills/grilling/SKILL.md
@@ -3,22 +3,12 @@ name: grilling
 description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
 ---
 
-Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
-Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled: the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
 
-Each question should be formatted like so:
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
 
-```
-❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
-
-➡️ <your recommended answer>
-```
-
-Each round the user answers reshapes the tree: settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
-
-Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it; don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report; ask the rest of the frontier now. The _decisions_ are the user's: put each to them and wait.
-
-The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.
+Do not act on it until I confirm we have reached a shared understanding.
 
 Ask through whichever picker tool the toolset offers — `AskUserQuestion` in Claude Code, `request_user_input` in Codex, Plan mode only — so answering costs me a keystroke. Without one, ask in prose rather than hand-rolling a menu.

--- a/agent/skills/grilling/agents/openai.yaml
+++ b/agent/skills/grilling/agents/openai.yaml
@@ -1,3 +1,3 @@
 interface:
   display_name: "Grilling"
-  short_description: "Stress-test thinking a round of questions at a time"
+  short_description: "Stress-test thinking one question at a time"


### PR DESCRIPTION
## 概要

grillingスキル末尾のピッカー使い分けの文が冗長だったため、要点を保ったまま短くした。

## 変更

- `genuinely narrows` → `narrows`
- `ask through whichever picker tool the toolset offers` → `use the toolset's picker`
- 挿入句 `, Plan mode only` を削除
- `ask an open question in prose` → `ask in prose`
- `force them into a menu` → `force a menu`

## 確認

- [x] 意味・指示内容を維持していることを確認
- [x] 行数・構造の変化なし（1行の置換）