### PR TITLE
chore(agent): remove grilling from skills.toml

### DIFF
--- a/agent/skills.toml
+++ b/agent/skills.toml
@@ -4,13 +4,9 @@
 # relative to the skill root; excluding a directory drops its subtree.
 
 [skills]
-playwright-cli = { url = "https://github.com/microsoft/playwright-cli.git", path = "skills/playwright-cli" }
-grilling = { url = "https://github.com/mattpocock/skills.git", path = "skills/productivity/grilling" }
-adversarial-panel = { url = "https://github.com/makinux/adversarial-panel.git", exclude = [
-    "assets",
-    "README*.md",
-] }
+playwright-cli           = { url = "https://github.com/microsoft/playwright-cli.git", path = "skills/playwright-cli" }
+adversarial-panel        = { url = "https://github.com/makinux/adversarial-panel.git", exclude = ["assets", "README*.md"] }
 cognitive-rhythm-writing = { url = "https://gist.github.com/k16shikano/eb2929f13ed19c97188393d297be8432.git" }
-japanese-tech-writing = { url = "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git" }
-ponytail = { url = "https://github.com/DietrichGebert/ponytail.git", path = "skills/ponytail" }
-ponytail-review = { url = "https://github.com/DietrichGebert/ponytail.git", path = "skills/ponytail-review" }
+japanese-tech-writing    = { url = "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git" }
+ponytail                 = { url = "https://github.com/DietrichGebert/ponytail.git", path = "skills/ponytail" }
+ponytail-review          = { url = "https://github.com/DietrichGebert/ponytail.git", path = "skills/ponytail-review" }


### PR DESCRIPTION
## 概要

grillingスキルを手動編集したため、vendoring対象から除外しました。それに伴い `skills.toml` の `[skills]` から `grilling` エントリを削除します。

## 変更内容

- `agent/skills.toml`: `grilling` エントリを1行削除

## 理由

grillingスキルは手動で編集したため、`./setup.py update` による上書き対象から外す必要があります。 `skills.toml` にエントリが残っていると、次回update時に手動編集内容が失われます。