### PR TITLE
chore(agent): remove subagent model overrides

### DIFF
--- a/agent/config/claude/agents/implementer.md
+++ b/agent/config/claude/agents/implementer.md
@@ -1,7 +1,6 @@
 ---
 name: implementer
 description: Implements an approved brief within its stated scope and runs the required verification
-model: sonnet
 ---
 
 Implement only the approved brief provided by the main agent.

--- a/agent/config/claude/agents/verifier.md
+++ b/agent/config/claude/agents/verifier.md
@@ -1,7 +1,6 @@
 ---
 name: verifier
 description: Independently audits an implementation against its approved brief and required verification
-model: opus
 tools:
   - Read
   - Grep

--- a/agent/config/codex/agents/implementer.toml
+++ b/agent/config/codex/agents/implementer.toml
@@ -1,6 +1,5 @@
 name = "implementer"
 description = "Implements an approved brief within its stated scope and runs the required verification."
-model = "gpt-5.6-terra"
 developer_instructions = """
 Implement only the approved brief provided by the main agent.
 

--- a/agent/config/codex/agents/verifier.toml
+++ b/agent/config/codex/agents/verifier.toml
@@ -1,6 +1,5 @@
 name = "verifier"
 description = "Independently audits an implementation against its approved brief and required verification."
-model = "gpt-5.6-sol"
 sandbox_mode = "read-only"
 developer_instructions = """
 Independently audit the implementation against the approved brief, applicable


### PR DESCRIPTION
## 背景

エージェント設定の `implementer` と `verifier` が特定モデルを固定しており、実行環境側のデフォルトモデル選択を利用できませんでした。

## 概要

Claude と Codex のサブエージェント設定からモデル指定を削除し、モデル未指定の状態にします。

## 変更内容

Claude の `implementer` / `verifier` front matter と Codex の `implementer` / `verifier` TOML から、モデル指定だけを削除しました。
ツール、権限、サンドボックス、エージェント指示は変更していません。
OpenCode の設定はもともとモデル未指定のため変更していません。

## 影響範囲

対象のサブエージェントは、各実行環境のデフォルトモデル選択に従います。
モデル指定以外のエージェント挙動と設定は維持されます。

## 検証

- [x] `rg -n --hidden -i '^model\\s*[:=]' agent/config/*/agents`：モデル指定の残存なし
- [x] `git diff --check origin/main...HEAD`：成功
- [x] `git diff --stat origin/main...HEAD`：4ファイル、4行削除のみ

## レビュー観点

- Claude / Codex の `implementer` と `verifier` がモデル未指定になっていること
- モデル指定以外の設定を変更していないこと