### PR TITLE
feat(agent): add workflow skills

### DIFF
--- a/agent/skills.lock.json
+++ b/agent/skills.lock.json
@@ -16,12 +16,12 @@
     "ref": "main",
     "url": "https://gist.github.com/k16shikano/eb2929f13ed19c97188393d297be8432.git"
   },
-  "grilling": {
-    "commit": "b1db3b2ed64d5aad4d655f5a00f0dc8aa0e9d227",
+  "handoff": {
+    "commit": "2261762b675904f636528634cc87d58379e53596",
     "exclude": [],
-    "path": "skills/productivity/grilling",
+    "path": "dot_agents/skills/handoff",
     "ref": "main",
-    "url": "https://github.com/mattpocock/skills.git"
+    "url": "https://github.com/kotek-7/dotfiles.git"
   },
   "japanese-tech-writing": {
     "commit": "c7189cdc9c2520be50418209834145bdf3a46e97",
@@ -30,25 +30,27 @@
     "ref": "main",
     "url": "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git"
   },
+  "onboard": {
+    "commit": "2261762b675904f636528634cc87d58379e53596",
+    "exclude": [],
+    "path": "dot_agents/skills/onboard",
+    "ref": "main",
+    "url": "https://github.com/kotek-7/dotfiles.git"
+  },
   "playwright-cli": {
-    "commit": "4f9d85a9472fc6d0c9a91ac62f3f3ecc24c16de2",
+    "commit": "2f85a94b7b885dbf4a5d34462f253a8746a690c9",
     "exclude": [],
     "path": "skills/playwright-cli",
     "ref": "main",
     "url": "https://github.com/microsoft/playwright-cli.git"
   },
-  "ponytail": {
-    "commit": "2ed6c52c9d7e5e56942508591085fd45dea277d3",
-    "exclude": [],
-    "path": "skills/ponytail",
+  "sanitize-artifacts": {
+    "commit": "2261762b675904f636528634cc87d58379e53596",
+    "exclude": [
+      "dot_DS_Store"
+    ],
+    "path": "dot_agents/skills/sanitize-artifacts",
     "ref": "main",
-    "url": "https://github.com/DietrichGebert/ponytail.git"
-  },
-  "ponytail-review": {
-    "commit": "2ed6c52c9d7e5e56942508591085fd45dea277d3",
-    "exclude": [],
-    "path": "skills/ponytail-review",
-    "ref": "main",
-    "url": "https://github.com/DietrichGebert/ponytail.git"
+    "url": "https://github.com/kotek-7/dotfiles.git"
   }
 }

--- a/agent/skills.toml
+++ b/agent/skills.toml
@@ -11,3 +11,8 @@ adversarial-panel = { url = "https://github.com/makinux/adversarial-panel.git", 
 ] }
 cognitive-rhythm-writing = { url = "https://gist.github.com/k16shikano/eb2929f13ed19c97188393d297be8432.git" }
 japanese-tech-writing = { url = "https://gist.github.com/k16shikano/fd287c3133457c4fd8f5601d34aa817d.git" }
+handoff = { url = "https://github.com/kotek-7/dotfiles.git", path = "dot_agents/skills/handoff" }
+onboard = { url = "https://github.com/kotek-7/dotfiles.git", path = "dot_agents/skills/onboard" }
+sanitize-artifacts = { url = "https://github.com/kotek-7/dotfiles.git", path = "dot_agents/skills/sanitize-artifacts", exclude = [
+    "dot_DS_Store",
+] }

--- a/agent/skills/handoff/SKILL.md
+++ b/agent/skills/handoff/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: "handoff"
+description: "Use when the user wants to transfer the current conversation, task state, project context, decisions, constraints, or next steps to another agent or a new chat. Produces a concise context handoff prompt that another agent should read before waiting for the user's next instruction."
+---
+
+# Handoff
+
+Use this skill to turn the current conversation and task state into a prompt that another agent can use to understand the context before waiting for the user's next instruction.
+
+## Principles
+
+- Output a standalone prompt addressed to the next agent.
+- Include only information needed to continue the work.
+- Separate confirmed facts from assumptions and unresolved questions.
+- Preserve user preferences, constraints, and safety rules that affect future actions.
+- The handoff prompt must not instruct the next agent to start editing, running commands, or continuing implementation automatically.
+- The next agent should only absorb the context and wait for the user's explicit next instruction.
+- Do not include hidden chain-of-thought, internal deliberation, or irrelevant conversation history.
+- Do not expose secrets, tokens, credentials, private keys, or sensitive file contents.
+- If sensitive context matters, describe its existence and location generically instead of copying values.
+
+## Workflow
+
+1. Identify the target handoff scope.
+   - Current task only, whole conversation, project setup, debugging state, implementation state, or review state.
+   - If the user does not specify, assume the current task and immediately relevant project context.
+2. Extract continuation-critical context.
+   - User goal.
+   - Repository/path and environment.
+   - Relevant files inspected or changed.
+   - Commands run and important outcomes.
+   - Decisions made and rationale.
+   - Constraints from `AGENTS.md` or user instructions.
+   - Current status, blockers, and next steps.
+3. Normalize the result.
+   - Remove apology, process chatter, and stale branches of discussion.
+   - Keep dates, versions, paths, and command names concrete.
+   - Mark uncertain details as assumptions.
+4. Produce a paste-ready prompt.
+   - Prefer one fenced text block.
+   - The prompt should tell the next agent to read the context and wait.
+   - List possible next steps as options or likely follow-up areas, not as commands to execute.
+   - Include a short "Do not" section for important safety constraints.
+   - After outputting the handoff prompt, stop. Do not begin any work described inside the handoff.
+
+## Output Template
+
+```text
+You are receiving context for an existing task.
+
+Read this context only. Do not edit files, run commands, or continue implementation until the user gives an explicit next instruction.
+
+Goal:
+- ...
+
+Context:
+- Working directory: ...
+- Environment: ...
+- Relevant project instructions: ...
+
+What has already been done:
+- ...
+
+Files changed:
+- ...
+
+Important findings:
+- ...
+
+Current status:
+- ...
+
+Possible next steps:
+- ...
+
+Constraints and cautions:
+- ...
+
+Wait for the user's next instruction before taking action.
+```
+
+When no files were changed, write `Files changed: none`.

--- a/agent/skills/handoff/agents/openai.yaml
+++ b/agent/skills/handoff/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Handoff"
+  short_description: "Generate an agent handoff prompt"

--- a/agent/skills/onboard/SKILL.md
+++ b/agent/skills/onboard/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: "onboard"
+description: "Use when first entering a project or when the user asks to understand, inspect, summarize, onboard, or get familiar with a repository. This skill performs read-only project orientation: structure, stack, important files, commands, tests, docs, risks, and next investigation targets."
+---
+
+# Onboard
+
+Use this skill at the start of work in an unfamiliar project. Keep the pass read-only unless the user explicitly asks for changes.
+
+## Scope
+
+Build a concise working model of the project:
+
+- purpose and domain
+- tech stack and package/build tools
+- repository structure
+- important entry points and configuration files
+- build, test, lint, run, and deployment commands
+- existing documentation and project instructions
+- likely risk areas and follow-up questions
+
+## Workflow
+
+1. Read project instructions first.
+   - Check `AGENTS.md`, `.codex/`, `.agents/`, README files, and docs that appear central.
+   - Treat nearer project instructions as more specific than global instructions.
+2. Map the repository structure.
+   - Prefer `rg --files` and shallow directory listings.
+   - Avoid dumping huge trees or reading generated/dependency directories.
+3. Detect the stack.
+   - Look for `package.json`, `pnpm-lock.yaml`, `yarn.lock`, `pyproject.toml`, `requirements.txt`, `Cargo.toml`, `go.mod`, `platformio.ini`, `CMakeLists.txt`, `compose.yaml`, CI workflows, and framework config files.
+4. Identify workflows.
+   - Extract scripts and commands from package/config files.
+   - Prefer documented commands over guessed commands.
+   - Note commands that are likely but unverified.
+5. Inspect key implementation paths.
+   - Read only representative files needed to understand architecture.
+   - Identify entry points, routes, services, hardware targets, or CLI commands depending on project type.
+6. Summarize without changing files.
+   - Keep the summary short and actionable.
+   - Separate confirmed facts from inferences.
+   - Call out unknowns that materially affect future work.
+
+## Output
+
+Use this structure when useful:
+
+- Project purpose
+- Stack and tools
+- Important files/directories
+- Run/test/build commands
+- Architecture notes
+- Existing docs/instructions
+- Risks or gotchas
+- Suggested next steps
+
+If the user asks for a deeper onboarding document, propose the target file and wait for explicit edit approval before creating it.

--- a/agent/skills/onboard/agents/openai.yaml
+++ b/agent/skills/onboard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Onboard"
+  short_description: "Understand a project before making changes"
+  default_prompt: "Use $onboard to inspect this repository and give me a concise project orientation."

--- a/agent/skills/sanitize-artifacts/SKILL.md
+++ b/agent/skills/sanitize-artifacts/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: sanitize-artifacts
+description: Inspect and revise generated artifacts so they read as natural, standalone deliverables, without leaking prompt instructions, conversation history, implementation constraints, or production process artifacts into user-facing content.
+---
+
+# sanitize-artifacts
+
+Use this skill when the user asks you to inspect, clean up, sanitize, revise, polish, or quality-check artifacts produced during the current work session.
+
+This skill is especially important when the artifact was produced through iterative prompting, corrective instructions, examples, constraints, or vibe-coding-style collaboration.
+
+## Goal
+
+Revise the artifact so that it stands on its own as a coherent final deliverable.
+
+The artifact must not expose unnecessary traces of:
+
+- the user's prompts
+- conversation history
+- intermediate reasoning
+- implementation constraints
+- tool choices
+- avoided approaches
+- prompt-engineering instructions
+- scaffolding used during production
+- examples that were provided only to guide intent
+- corrective feedback given during the conversation
+
+The final artifact should look like it was intentionally designed for its real audience, not assembled from the conversation that produced it.
+
+## Core Principle
+
+Treat the conversation as production context, not automatically as artifact content.
+
+Before preserving any statement in the artifact, classify it as one of the following:
+
+1. User-facing content that the artifact's audience genuinely needs
+2. Production guidance that should influence the artifact but should not be visible
+3. Incidental conversation residue that should be removed
+
+Only category 1 should appear directly in the artifact.
+
+Category 2 should be reflected indirectly through structure, tone, scope, assumptions, defaults, examples, naming, or design choices.
+
+Category 3 should be removed.
+
+## What to Remove or Rewrite
+
+Look for and remove or rewrite content that unnecessarily says or implies:
+
+- "As requested..."
+- "Based on your instruction..."
+- "We will not use..."
+- "This avoids..."
+- "Unlike the previous version..."
+- "The user wanted..."
+- "This document assumes..."
+- "Because of the constraint..."
+- "No Git/Homebrew/CLI/etc. is used..."
+- "This was changed to..."
+- "The prompt says..."
+- "The conversation so far..."
+- "This section was added because..."
+- "To satisfy the requirement..."
+
+Do not remove such content mechanically. Keep it only when the intended audience genuinely needs to know it.
+
+## Examples vs. Intent
+
+If the user gave an example to communicate intent, do not copy that example into the artifact unless the artifact itself specifically needs it.
+
+Examples from the conversation are usually diagnostic material, not final content.
+
+Use examples to infer:
+
+- the desired level of abstraction
+- the audience
+- the tone
+- what kinds of leakage to avoid
+- what kinds of unnatural wording to remove
+- what design constraints matter
+
+Do not let examples accidentally become the topic of the artifact.
+
+## Constraints Are Usually Invisible
+
+User constraints should normally affect the artifact's design, not appear as explicit disclaimers.
+
+For example:
+
+Bad:
+
+> This guide does not use Git, Homebrew, or additional CLI tools.
+
+Better:
+
+> Share the project folder using Google Drive.
+
+The better version applies the constraint without exposing it as a production rule.
+
+## Inspection Checklist
+
+When sanitizing an artifact, check:
+
+1. Does the artifact read naturally to someone who never saw the conversation?
+2. Are there any sentences that explain why the artifact was written this way?
+3. Are there any unnecessary mentions of tools, exclusions, constraints, or avoided alternatives?
+4. Did a prompt example accidentally become part of the deliverable?
+5. Are there signs of patchwork from multiple rounds of feedback?
+6. Are tone, terminology, and assumptions consistent throughout?
+7. Are headings and notes written for the artifact's audience rather than for the creator?
+8. Is any meta-commentary present that belongs only in the production process?
+9. Are disclaimers or caveats included only when the audience truly needs them?
+10. Does the artifact have a single coherent voice?
+
+## Revision Strategy
+
+Prefer rewriting over explaining.
+
+Do not add a report about what you sanitized unless the user asks for one.
+
+When editing, preserve the artifact's intended purpose, technical correctness, and necessary user-facing requirements.
+
+Remove production residue by converting it into natural artifact design.
+
+For example:
+
+- Convert "Do not use advanced terms" into simpler wording.
+- Convert "Avoid CLI black boxes" into clear, concrete steps.
+- Convert "Use Google Drive, not Git" into Drive-based workflow instructions.
+- Convert "Beginner-friendly" into pacing, definitions, and examples.
+- Convert "Do not mention X" into omission of X, not a statement that X is omitted.
+
+## Output Rules
+
+When asked to sanitize an artifact, output the revised artifact itself.
+
+Do not preface the artifact with process commentary such as:
+
+- "I removed the meta instructions."
+- "I cleaned up the prompt leakage."
+- "Here is the sanitized version."
+
+A brief label is acceptable only if needed for clarity.
+
+If the user asks for both the sanitized artifact and a change summary, put the artifact first and the summary after it.
+
+## Quality Bar
+
+The sanitized artifact should feel intentional, unified, and audience-native.
+
+A reader should not be able to infer the prompting history, internal constraints, or corrective conversation unless those details are genuinely part of the deliverable.

--- a/agent/skills/sanitize-artifacts/agents/openai.yaml
+++ b/agent/skills/sanitize-artifacts/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: Sanitize Artifacts
+  short_description: Removes conversation-dependent wording from implementation outputs.
+  icon: 🧹
+  color: blue


### PR DESCRIPTION
## 背景

エージェントの作業引継ぎ、リポジトリ初見時の調査、生成物の最終品質確認を、再利用できるスキルとして配布する。スキル更新時に生成される `dot_DS_Store` は配布対象に含めない。

## 概要

3つのワークフロースキルを登録・同梱し、ロックファイルを宣言と同期する。

## 変更内容

- handoff、onboard、sanitize-artifacts を外部ソースから取得するスキルとして追加する。
- スキル更新の再現性のため取得コミットを固定し、宣言されていない古いロック項目を整理する。
- sanitize-artifacts の取得対象から `dot_DS_Store` を除外する。

## 影響範囲

エージェント設定のスキル一覧だけが変わる。アプリケーションの実行時契約、設定形式、既存スキルの本文は変更しない。

## 検証

- [x] マニフェスト、ロック、全スキルの `SKILL.md` の対応関係を検査：7件すべて一致。
- [x] `git diff --cached --check`：空白エラーなし。
- [ ] `agent/setup.py install`：ユーザー環境のグローバル symlink を変更するため未実施。

## レビュー観点

- 各スキルの責務と提供元がこのリポジトリのエージェント運用に適切か。
- `sanitize-artifacts` の `dot_DS_Store` 除外が更新時も生成物を取り込まないこと。